### PR TITLE
chore: Replace undici fetch with undici request

### DIFF
--- a/common/changes/@nicktomlin/rush-mono-http/undici_2022-04-22-15-12.json
+++ b/common/changes/@nicktomlin/rush-mono-http/undici_2022-04-22-15-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@nicktomlin/rush-mono-http",
+      "comment": "Replace our usage of undici fetch with undici request",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@nicktomlin/rush-mono-http"
+}

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -1,8 +1,8 @@
-import {fetch} from 'undici';
+import {request} from 'undici';
 
 export class Client {
   async run () {
-    const res = await fetch('https://httpbin.org/get')
-    return res.json()
+    const {body} = await request('https://httpbin.org/get')
+    return body.json()
   }
 }


### PR DESCRIPTION
This removes an `experimental` warning